### PR TITLE
Factorial panics if floating point value is given

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -115,7 +115,7 @@ func init() {
 	funcs.register("fact", &function{
 		arity: 1,
 		fn: func(args []float64) float64 {
-			return float64(Factorial(int64(args[0] + 0.5)))
+			return float64(Factorial(int64(args[0])))
 		},
 	})
 	funcs.register("gcd", &function{

--- a/functions.go
+++ b/functions.go
@@ -115,7 +115,7 @@ func init() {
 	funcs.register("fact", &function{
 		arity: 1,
 		fn: func(args []float64) float64 {
-			return Factorial(args[0])
+			return float64(Factorial(int64(args[0] + 0.5)))
 		},
 	})
 	funcs.register("gcd", &function{
@@ -137,8 +137,8 @@ func init() {
 }
 
 // Factorial calculates the factorial of number n
-func Factorial(n float64) float64 {
-	if n == 0 {
+func Factorial(n int64) int64 {
+	if n <= 1 {
 		return 1
 	}
 

--- a/functions_test.go
+++ b/functions_test.go
@@ -52,7 +52,7 @@ func TestFunctionsResult(t *testing.T) {
 		"sqrt(144)":                         math.Sqrt(144),
 		"tan(144) + tan(-3) + sin(5)":       -1.380026998425437,
 		"fact(6) * fact(7) == fact(10)":     1,
-		"fact(5.5) * fact(7.3) == fact(10)": 1,
+		"fact(6.5) * fact(7.3) == fact(10)": 1,
 	}
 
 	for expr, expected := range calls {

--- a/functions_test.go
+++ b/functions_test.go
@@ -37,21 +37,22 @@ func TestFunctions(t *testing.T) {
 
 func TestFunctionsResult(t *testing.T) {
 	calls := map[string]float64{
-		"abs(-700)":                     math.Abs(-700),
-		"ceil(813.23)":                  math.Ceil(813.23),
-		"floor(813.23)":                 math.Floor(813.23),
-		"sin(74)":                       math.Sin(74),
-		"cos(74)":                       math.Cos(74),
-		"tan(74)":                       math.Tan(74),
-		"asin(-1)":                      math.Asin(-1),
-		"acos(-1)":                      math.Acos(-1),
-		"atan(-1)":                      math.Atan(-1),
-		"log(3*100)":                    math.Log(3 * 100),
-		"max(5, 8)":                     math.Max(5, 8),
-		"min(5, 8)":                     math.Min(5, 8),
-		"sqrt(144)":                     math.Sqrt(144),
-		"tan(144) + tan(-3) + sin(5)":   -1.380026998425437,
-		"fact(6) * fact(7) == fact(10)": 1,
+		"abs(-700)":                         math.Abs(-700),
+		"ceil(813.23)":                      math.Ceil(813.23),
+		"floor(813.23)":                     math.Floor(813.23),
+		"sin(74)":                           math.Sin(74),
+		"cos(74)":                           math.Cos(74),
+		"tan(74)":                           math.Tan(74),
+		"asin(-1)":                          math.Asin(-1),
+		"acos(-1)":                          math.Acos(-1),
+		"atan(-1)":                          math.Atan(-1),
+		"log(3*100)":                        math.Log(3 * 100),
+		"max(5, 8)":                         math.Max(5, 8),
+		"min(5, 8)":                         math.Min(5, 8),
+		"sqrt(144)":                         math.Sqrt(144),
+		"tan(144) + tan(-3) + sin(5)":       -1.380026998425437,
+		"fact(6) * fact(7) == fact(10)":     1,
+		"fact(5.5) * fact(7.3) == fact(10)": 1,
 	}
 
 	for expr, expected := range calls {


### PR DESCRIPTION
The factorial function was causing a panic if called with a floating point number or a negative value. I  changed it to int64 values to avoid the stack overflow.

Please accept my pull request. If you have any improvements don't hesitate to tell them to me.
