### PR TITLE
When using mathcat.Exec() multiple times - Old variables from previous execution will be available in expression

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -33,21 +33,27 @@ var (
 	ErrAssignToLiteral      = errors.New("Can't assign to literal")
 )
 
-// Some useful predefined variables that can be used in expressions. These
-// can be overwritten.
-var constants = map[string]float64{
-	"pi":  math.Pi,
-	"tau": math.Pi * 2,
-	"phi": math.Phi,
-	"e":   math.E,
-}
+// // Some useful predefined variables that can be used in expressions. These
+// // can be overwritten.
+// var constants = map[string]float64{
+// 	"pi":  math.Pi,
+// 	"tau": math.Pi * 2,
+// 	"phi": math.Phi,
+// 	"e":   math.E,
+// }
 
 // New initializes a new Parser instance, useful when you want to run multiple
 // expression and/or use variables.
 func New() *Parser {
+
 	return &Parser{
-		pos:       0,
-		Variables: constants,
+		pos: 0,
+		Variables: map[string]float64{
+			"pi":  math.Pi,
+			"tau": math.Pi * 2,
+			"phi": math.Phi,
+			"e":   math.E,
+		},
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -33,15 +33,6 @@ var (
 	ErrAssignToLiteral      = errors.New("Can't assign to literal")
 )
 
-// // Some useful predefined variables that can be used in expressions. These
-// // can be overwritten.
-// var constants = map[string]float64{
-// 	"pi":  math.Pi,
-// 	"tau": math.Pi * 2,
-// 	"phi": math.Phi,
-// 	"e":   math.E,
-// }
-
 // New initializes a new Parser instance, useful when you want to run multiple
 // expression and/or use variables.
 func New() *Parser {


### PR DESCRIPTION
The use of
`mathcat.exec("i1+i2", map[string]float64{"i1":1.0, i2:2.0})`
and then
`mathcat.exec("i1+i2", map[string]float64{"i1":1.0})`
in the same process will be valid.

The `constants` map in  parser.go is a _static_ field which will not be reinitialised by `New()`.
So all the variables used within one process will be available for every later use.

The easiest way to avoid this behaviour is the initialisation of the map in the constructor.
Another possible, but expensive, way is to clone the map via a loop.